### PR TITLE
Catch undefined in case if widget is custom.

### DIFF
--- a/public/js/dashboard-configure.js
+++ b/public/js/dashboard-configure.js
@@ -1101,8 +1101,11 @@ class DashboardConfigure {
             return null;
         }
 
-        let config = this.dashboardContent.rows[rowKey].cols[colId].widgets[widgetId];
-        if (config === undefined) {
+        let config = null;
+
+        try {
+            config = this.dashboardContent.rows[rowKey].cols[colId].widgets[widgetId];
+        } catch (e) {
             return null;
         }
 


### PR DESCRIPTION
Undefined error was produced which blocked widget configuration.